### PR TITLE
Redraw without breaking 'incsearch' in search command line

### DIFF
--- a/autoload/pum.vim
+++ b/autoload/pum.vim
@@ -278,7 +278,12 @@ function! s:open(startcol, items, mode) abort
     call pum#map#select_relative(+1)
   elseif a:mode ==# 'c'
     " Note: :redraw is needed for command line completion
-    redraw
+    if &incsearch && (getcmdtype() ==# '/' || getcmdtype() ==# '?')
+      " redraw without breaking 'incsearch' in search command
+      call feedkeys("\<C-R>\<BS>", 'n')
+    else
+      redraw
+    endif
   endif
 
   augroup pum


### PR DESCRIPTION
## Problem
`:redraw` clears highlight of `'incsearch'`.
This is inconvenient when using ddc.vim in search command line.

## Solution
The fix is from wilder.nvim.
https://github.com/gelguy/wilder.nvim/blob/f50d79a3f9ef07be3c0c8a0f49faaeea803a8c0c/autoload/wilder/renderer.vim#L10-L15