### PR TITLE
Change to complete even if input exactly matches

### DIFF
--- a/autoload/pum/map.vim
+++ b/autoload/pum/map.vim
@@ -257,11 +257,6 @@ function! s:setline(text) abort
   endif
 endfunction
 function! s:insertline(text, after_func) abort
-  let current_word = pum#_getline()[pum#_get().startcol - 1 : pum#_col() - 2]
-  if current_word ==# a:text
-    return
-  endif
-
   " Note: ":undojoin" is needed to prevent undo breakage
   let tree = undotree()
   if tree.seq_cur == tree.seq_last
@@ -273,6 +268,7 @@ function! s:insertline(text, after_func) abort
   if mode() ==# 'i'
     let chars .= "\<Cmd>set backspace=start\<CR>"
   endif
+  let current_word = pum#_getline()[pum#_get().startcol - 1 : pum#_col() - 2]
   let chars .= repeat("\<BS>", strchars(current_word)) . a:text
   if mode() ==# 'i'
     let chars .= printf("\<Cmd>set backspace=%s\<CR>", &backspace)


### PR DESCRIPTION
# Problem

Unlike built-in popup menu, `pum#map#confirm()` does not close the popup or call autocmd `PumCompleteDone` if the input exactly matches with the `word` of the selected item.
This sometimes make snippet items to not expand correctly.

# Solution

This PR changes `pum#map#confirm()` to close the popup and call `PumCompleteDone` even if the input exactly matches with the `word` of the selected item.

# Configuration and behavior

Use [Shougo/ddc.vim](https://github.com/Shougo/ddc.vim) and [hrsh7th/vim-vsnip](https://github.com/hrsh7th/vim-vsnip).

```vim
let s:dein_dir = expand('<sfile>:h') .. '/dein'

let &runtimepath .= ',' .. s:dein_dir .. '/repos/github.com/Shougo/dein.vim'

call dein#begin(s:dein_dir)
call dein#add('vim-denops/denops.vim')
call dein#add('Shougo/ddc.vim')
call dein#add('Shougo/pum.vim')
call dein#add('Shougo/ddc-matcher_head')
call dein#add('hrsh7th/vim-vsnip')
call dein#add('hrsh7th/vim-vsnip-integ')
call dein#add('rafamadriz/friendly-snippets')
call dein#end()

set completeopt=menuone,noinsert

autocmd User PumCompleteDone call vsnip_integ#on_complete_done(g:pum#completed_item)

inoremap <expr> <Tab> ddc#map#extend()

call ddc#custom#patch_global('sources', ['vsnip'])
call ddc#custom#patch_global('sourceOptions', {
    \     '_': {
    \         'matchers': ['matcher_head'],
    \     },
    \ })
call ddc#custom#patch_global('completionMenu', 'pum.vim') " Works correctly without this line
call ddc#enable()

filetype plugin indent on
syntax enable
```

https://user-images.githubusercontent.com/77492100/166154694-5268d8ad-d287-4c41-9790-3a28d6adda0d.mp4