### PR TITLE
Include border size for pum#get_pos()

### DIFF
--- a/autoload/pum.vim
+++ b/autoload/pum.vim
@@ -29,6 +29,8 @@ function! pum#_init() abort
         \ 'startcol': -1,
         \ 'startrow': -1,
         \ 'width': -1,
+        \ 'border_width': 0,
+        \ 'border_height': 0,
         \}
 endfunction
 function! pum#_options() abort
@@ -120,8 +122,8 @@ function! pum#get_pos() abort
 
   let pum = pum#_get()
   return {
-        \ 'height': pum.height,
-        \ 'width': pum.width,
+        \ 'height': pum.height + pum.border_height,
+        \ 'width': pum.width + pum.border_width,
         \ 'row': pum.pos[0],
         \ 'col': pum.pos[1],
         \ 'size': pum.len,

--- a/autoload/pum/popup.vim
+++ b/autoload/pum/popup.vim
@@ -208,6 +208,8 @@ function! pum#popup#_open(startcol, items, mode) abort
   let pum.direction = direction
   let pum.height = height
   let pum.width = width
+  let pum.border_width = border_left + border_right
+  let pum.border_height = border_top + border_bottom
   let pum.len = len(items)
   let pum.reversed = reversed
   let pum.startcol = a:startcol


### PR DESCRIPTION
Fix for https://github.com/matsui54/denops-popup-preview.vim/issues/16 .