### PR TITLE
Fix `pum#visible()` and `pum#entered()` doesn't return `v:true`

### DIFF
--- a/autoload/pum.vim
+++ b/autoload/pum.vim
@@ -110,13 +110,17 @@ function! pum#close() abort
   call pum#popup#_close(scroll_id)
 endfunction
 
+function! s:to_bool(int_boolean_value) abort
+  return a:int_boolean_value ==# 1 ? v:true : v:false
+endfunction
+
 function! pum#visible() abort
-  return pum#_get().id > 0
+  return s:to_bool(pum#_get().id > 0)
 endfunction
 
 function! pum#entered() abort
   let info = pum#complete_info()
-  return info.pum_visible && (info.selected >= 0 || info.inserted != '')
+  return s:to_bool(info.pum_visible && (info.selected >= 0 || info.inserted != ''))
 endfunction
 
 function! pum#complete_info(...) abort


### PR DESCRIPTION
In [documentation](https://github.com/Shougo/pum.vim/blob/00ce3ea23701cfd8fa3a21d8ee04c4791adc6678/doc/pum.txt#L262-L265), `pum#visible()` will return `v:true` .

But `pum#visible()` returns `1` when pum is displayed.

This behavior cause some problems when called the function from Neovim-lua.

```lua
vim.keymap.set('i', '<CR>', function()
  if not vim.fn['pum#visible']() then -- This condition does not work.
    return vim.fn['lexima#expand']('<lt>CR>', 'i')
  end
  return '<Cmd>call pum#map#confirm()<CR>'
end, { expr = true })
```