### PR TITLE
Fix luacheck was always fail

### DIFF
--- a/autoload/pum/util.vim
+++ b/autoload/pum/util.vim
@@ -58,6 +58,6 @@ function! s:strwidthpart_reverse(str, width) abort
 endfunction
 
 function! pum#util#_luacheck(module) abort
-  return has('nvim') && luaeval('pcall(require, _A.module)',
-        \ #{ module: a:module }) == v:t_dict
+  return has('nvim') && luaeval('type(select(2, pcall(require, _A.module))) == "table"',
+        \ #{ module: a:module })
 endfunction


### PR DESCRIPTION
Return value pattern of `pcall()` is `false, errormsg` or `true, value` and some modules are not compatible to vim value.
For example, `noice.nvim` integration is not work because this problem.
Therefore this PR change to use `select()` and compare type within lua.
