### PR TITLE
fix: Invoke CmdlineChanged on confirm

### DIFF
--- a/autoload/pum/map.vim
+++ b/autoload/pum/map.vim
@@ -324,11 +324,13 @@ endfunction
 
 function! s:setcmdline(text) abort
   if exists('*setcmdline')
-    call setcmdline(a:text)
+    " NOTE: CmdlineChanged autocmd must be disabled
+    noautocmd call setcmdline(a:text)
 
     " NOTE: skip_count is needed
     " CmdlineChanged is triggered after setcmdline() call
     let s:skip_count = 2
+    execute 'doautocmd <nomodeline> CmdlineChanged' getcmdtype()
   else
     " Clear cmdline
     let chars = "\<C-e>\<C-u>"

--- a/autoload/pum/map.vim
+++ b/autoload/pum/map.vim
@@ -324,14 +324,11 @@ endfunction
 
 function! s:setcmdline(text) abort
   if exists('*setcmdline')
-    " NOTE: CmdlineChanged autocmd must be disabled
-    noautocmd call setcmdline(a:text)
+    call setcmdline(a:text)
 
-    if !has('nvim')
-      " NOTE: skip_count is needed for Vim
-      " CmdlineChanged is triggered after setcmdline() call
-      let s:skip_count = 2
-    endif
+    " NOTE: skip_count is needed
+    " CmdlineChanged is triggered after setcmdline() call
+    let s:skip_count = 2
   else
     " Clear cmdline
     let chars = "\<C-e>\<C-u>"

--- a/doc/pum.txt
+++ b/doc/pum.txt
@@ -284,7 +284,6 @@ pum#map#cancel()
 pum#map#confirm()
 		Insert the select and close the popup.
 		Note: It must not be called in |:map-<expr>|.
-		Note: It does not call |CmdlineChanged| autocmd.
 
 						*pum#map#insert_relative()*
 pum#map#insert_relative({delta})


### PR DESCRIPTION
## Problem

After sourcing this script, the content of `g:lines` is expected `['foo']` but `['']`.
This means `CmdlineChanged` autocmd isn't invoked when `pum#map#confirm()` is called.

https://gist.github.com/fa875de95d7e59180c16575e99c21205

## Solution

- Make not to use `noautocmd` in `s:setcmdline()`.
- Set `skip_count` to notify to completion engine.
