### PR TITLE
Redraw the window for the insert mode

### DIFF
--- a/autoload/pum/map.vim
+++ b/autoload/pum/map.vim
@@ -16,7 +16,7 @@ function! pum#map#select_relative(delta, overflow='loop') abort
 
   let pum.cursor += delta
 
-  const redraw_cmd = (mode() ==# 'c' ? '| redraw' : '')
+  const redraw_cmd = index(['i', 'c'], mode()) >= 0 ? '| redraw' : ''
 
   if pum.cursor > pum.len || pum.cursor <= 0
     if a:overflow ==# 'empty'


### PR DESCRIPTION
I found that `pum.vim` now only shows the first page of completion candidates even if we try to scroll down the page when we have candidates more than `max_height` in the Insert mode. If my investigation is correct, it's because [this change](https://github.com/Shougo/pum.vim/commit/d7d09a29b52298a75f62e7280a567a414a2bb0c9) makes `pum.vim` redraw the screen only if the current mode is Command-line.
So, this PR makes `pum.vim` redraw the screen even if the current mode is Insert in addition to Command-line.