### PR TITLE
Fix option name

### DIFF
--- a/doc/pum.txt
+++ b/doc/pum.txt
@@ -122,8 +122,8 @@ highlight_normal_menu
 
 		Default: "Pmenu"
 
-					*pum-options-highlight_scrollbar*
-highlight_scrollbar
+					*pum-options-highlight_scroll_bar*
+highlight_scroll_bar
 		The scrollbar highlight.
 		Note: neovim only feature.
 


### PR DESCRIPTION
Fixed because the option name written in the document was different from the option name actually used.