### PR TITLE
Fix two bugs in command line completion.

### DIFF
--- a/autoload/pum/popup.vim
+++ b/autoload/pum/popup.vim
@@ -543,7 +543,7 @@ function! s:highlight(
   let pum = pum#_get()
 
   let col = a:col
-  if pum#_options().padding && pum.startcol != 1
+  if pum#_options().padding && (mode() ==# 'c' || pum.startcol != 1)
     let col += 1
   endif
 

--- a/autoload/pum/popup.vim
+++ b/autoload/pum/popup.vim
@@ -52,7 +52,7 @@ function! pum#popup#_open(startcol, items, mode, insert) abort
 
   " Padding
   let width += max_columns->len() - 1
-  if options.padding && a:startcol != 1
+  if options.padding && (a:mode ==# 'c' || a:startcol != 1)
     let width += 2
   endif
   if options.min_width > 0


### PR DESCRIPTION
Both of these bugs occur when pum#_options().padding is true and the start of the completion is in the first column.
