### PR TITLE
fix: Execute redraw outside of win_execute()

### DIFF
--- a/autoload/pum/map.vim
+++ b/autoload/pum/map.vim
@@ -31,8 +31,9 @@ function pum#map#select_relative(delta, overflow='empty') abort
       if pum.horizontal_menu
         call pum#popup#_redraw_horizontal_menu()
       else
+        call win_execute(pum.id, 'call cursor(1, 0)')
         " NOTE: redraw is required
-        call win_execute(pum.id, 'call cursor(1, 0) | redraw')
+        redraw
 
         if pum#_check_cmdwin()
           redraw!
@@ -66,12 +67,6 @@ function pum#map#select_relative(delta, overflow='empty') abort
   if pum.horizontal_menu
     call pum#popup#_redraw_horizontal_menu()
   else
-    " NOTE: ":redraw" is needed if it is Vim or in command line mode or
-    " scrollbar is disabled.
-    const redraw_cmd =
-          \ (!has('nvim') || mode() ==# 'c' || pum.scroll_id < 0) ?
-          \ '| redraw' : ''
-
     " Move real cursor
     " NOTE: If up scroll, cursor must adjust...
     " NOTE: Use matchaddpos() instead of nvim_buf_add_highlight() or prop_add()
@@ -80,14 +75,17 @@ function pum#map#select_relative(delta, overflow='empty') abort
       call win_execute(pum.id, '
             \   call cursor(pum#_get().cursor, 0)
             \ | call matchaddpos(pum#_options().highlight_selected,
-            \                    [pum#_get().cursor], 0, pum#_cursor_id())
-            \' .. redraw_cmd)
+            \                    [pum#_get().cursor], 0, pum#_cursor_id())')
     else
       call win_execute(pum.id, '
             \   call cursor(pum#_get().cursor + 1, 0)
             \ | call matchaddpos(pum#_options().highlight_selected,
-            \                    [pum#_get().cursor], 0, pum#_cursor_id())
-            \' .. redraw_cmd)
+            \                    [pum#_get().cursor], 0, pum#_cursor_id())')
+    endif
+    " NOTE: ":redraw" is needed if it is Vim or in command line mode or
+    " scrollbar is disabled.
+    if !has('nvim') || mode() ==# 'c' || pum.scroll_id < 0
+      redraw
     endif
 
     if pum#_check_cmdwin()

--- a/autoload/pum/popup.vim
+++ b/autoload/pum/popup.vim
@@ -266,7 +266,6 @@ function pum#popup#_open(startcol, items, mode, insert) abort
               \ printf('Normal:%s,NormalFloat:None',
               \        options.highlight_scrollbar))
         call nvim_win_set_option(scroll_id, 'winblend', &l:pumblend)
-        call nvim_win_set_option(scroll_id, 'statusline', &l:statusline)
 
         let pum.scroll_id = scroll_id
       endif
@@ -307,7 +306,8 @@ function pum#popup#_open(startcol, items, mode, insert) abort
 
   if reversed
     " The cursor must be end
-    call win_execute(pum.id, 'call cursor("$", 0) | redraw')
+    call win_execute(pum.id, 'call cursor("$", 0)')
+    redraw
 
     if pum.scroll_id > 0 && has('nvim')
       call nvim_win_set_config(pum.scroll_id, #{
@@ -835,5 +835,4 @@ function s:set_window_options(id, options, highlight) abort
   call nvim_win_set_option(a:id, 'winblend', &l:pumblend)
   call nvim_win_set_option(a:id, 'wrap', v:false)
   call nvim_win_set_option(a:id, 'scrolloff', 0)
-  call nvim_win_set_option(a:id, 'statusline', &l:statusline)
 endfunction


### PR DESCRIPTION
SSIA

In Neovim if `'laststatus'` is 3, status line of current window (floatwin) will be redrew while `win_execute()`.
