### PR TITLE
Fix scrollbar position when using border. (neovim only)

### DIFF
--- a/autoload/pum/popup.vim
+++ b/autoload/pum/popup.vim
@@ -211,7 +211,7 @@ function pum#popup#_open(startcol, items, mode, insert) abort
           \ (height * ((height + 0.0) / lines->len()) + 0.5
           \ )->floor()->float2nr(), 1]->max()
 
-    const scroll_row = pos[0]
+    const scroll_row = pos[0] + border_top
     const scroll_col = pos[1] + width
     let scroll_winopts = #{
           \   relative: 'editor',


### PR DESCRIPTION
# Summary

Fixed a bug where scrollbars were misaligned when using the border setting.

## Environment Information (Required!)

- pum.vim version(SHA1):d1b9579b4614f65c78c18dd9ac875afd397be867

- OS:Ubuntu 22.04.2 LTS on Windows 10 x86_64

- neovim/Vim `:version` output:NVIM v0.10.0-dev-836+g6d93bdd45-Homebrew

## Provide a minimal init.vim/vimrc without plugin managers (Required!)

```vim
set rtp+=/path/to/pum.vim

function! g:Create_dummy_items(qty) abort
  let items = []
  for i in range(1, a:qty)
    call add(items, #{ word: 'test' .. i, kind: 'Test', menu: '[test]' })
  endfor
  return items
endfunction

call pum#set_option(#{
      \   max_height: 20,
      \   border: 'single',
      \ })

inoremap <C-n> <Cmd>call pum#map#insert_relative(+1)<CR>
inoremap <C-p> <Cmd>call pum#map#insert_relative(-1)<CR>
inoremap <C-Space> <Cmd>call pum#open(col('.'), g:Create_dummy_items(40))<CR>

```

## How to reproduce the problem from neovim/Vim startup (Required!)

1. Press `<C-Space>` in insert mode

## Screen shot (if possible)
- before  
![before](https://github.com/Shougo/pum.vim/assets/100141359/156bf9ac-6462-4ec8-8141-c6899ba54653)

- after  
![after](https://github.com/Shougo/pum.vim/assets/100141359/6018db71-63a5-45d5-b541-c319ba891541)
