### PR TITLE
fix: Improve highlight_selected

### DIFF
--- a/autoload/pum.vim
+++ b/autoload/pum.vim
@@ -1,6 +1,5 @@
 let g:pum#_namespace = has('nvim') ? nvim_create_namespace('pum') : 0
 let g:pum#completed_item = {}
-let s:pum_cursor_id = 50
 
 
 function pum#_get() abort
@@ -286,10 +285,6 @@ function pum#_col() abort
         \ mode() ==# 'c' ? getcmdpos() :
         \ mode() ==# 't' ? '.'->col() : '.'->col()
   return col
-endfunction
-
-function pum#_cursor_id() abort
-  return s:pum_cursor_id
 endfunction
 
 function pum#_format_item(

--- a/autoload/pum/map.vim
+++ b/autoload/pum/map.vim
@@ -9,11 +9,6 @@ function pum#map#select_relative(delta, overflow='empty') abort
     let delta *= -1
   endif
 
-  " Clear current highlight
-  if !pum.horizontal_menu
-    silent! call matchdelete(pum#_cursor_id(), pum.id)
-  endif
-
   let pum.cursor += delta
 
   if pum.cursor > pum.len || pum.cursor <= 0
@@ -32,6 +27,7 @@ function pum#map#select_relative(delta, overflow='empty') abort
         call pum#popup#_redraw_horizontal_menu()
       else
         call win_execute(pum.id, 'call cursor(1, 0)')
+        call pum#popup#_redraw_selected()
       endif
 
       " Reset scroll bar
@@ -66,19 +62,12 @@ function pum#map#select_relative(delta, overflow='empty') abort
   else
     " Move real cursor
     " NOTE: If up scroll, cursor must adjust...
-    " NOTE: Use matchaddpos() instead of nvim_buf_add_highlight() or prop_add()
-    " Because the highlight conflicts with other highlights
     if delta < 0
-      call win_execute(pum.id, '
-            \   call cursor(pum#_get().cursor, 0)
-            \ | call matchaddpos(pum#_options().highlight_selected,
-            \                    [pum#_get().cursor], 0, pum#_cursor_id())')
+      call win_execute(pum.id, 'call cursor(pum#_get().cursor, 0)')
     else
-      call win_execute(pum.id, '
-            \   call cursor(pum#_get().cursor + 1, 0)
-            \ | call matchaddpos(pum#_options().highlight_selected,
-            \                    [pum#_get().cursor], 0, pum#_cursor_id())')
+      call win_execute(pum.id, 'call cursor(pum#_get().cursor + 1, 0)')
     endif
+    call pum#popup#_redraw_selected()
 
     call pum#popup#_redraw_scroll()
   endif

--- a/autoload/pum/popup.vim
+++ b/autoload/pum/popup.vim
@@ -509,8 +509,8 @@ function s:highlight_items(items, max_columns) abort
       for hl in item_highlights->copy()->filter(
             \ {_, val -> val.type ==# order})
         call s:highlight(
-              \ hl.hl_group, hl.name, 1,
-              \ g:pum#_namespace, row, start + hl.col - 1, hl.width)
+              \ hl.hl_group, hl.name, 2,
+              \ row, start + hl.col - 1, hl.width)
       endfor
 
       " NOTE: The byte length of multibyte characters may be larger than
@@ -524,7 +524,7 @@ function s:highlight_items(items, max_columns) abort
       if highlight_column !=# ''
         call s:highlight(
               \ highlight_column, 'pum_' .. order, 0,
-              \ g:pum#_namespace, row, start, width)
+              \ row, start, width)
       endif
 
       let start += width
@@ -532,8 +532,7 @@ function s:highlight_items(items, max_columns) abort
   endfor
 endfunction
 
-function s:highlight(
-      \ highlight, prop_type, priority, id, row, col, length) abort
+function s:highlight(highlight, prop_type, priority, row, col, length) abort
   let pum = pum#_get()
 
   let col = a:col
@@ -542,7 +541,7 @@ function s:highlight(
   endif
 
   if has('nvim')
-    return nvim_buf_set_extmark(pum.buf, a:id, a:row - 1, col - 1, #{
+    return nvim_buf_set_extmark(pum.buf, g:pum#_namespace, a:row - 1, col - 1, #{
           \   end_col: col - 1 + a:length,
           \   hl_group: a:highlight,
           \   priority: a:priority,
@@ -559,7 +558,6 @@ function s:highlight(
           \   length: a:length,
           \   type: a:prop_type,
           \   bufnr: pum.buf,
-          \   id: a:id,
           \ })
     return -1
   endif
@@ -585,8 +583,7 @@ function pum#popup#_redraw_selected() abort
   let length = pum.buf->getbufline(pum.cursor)[0]->strwidth()
   let s:pum_selected_id = s:highlight(
         \ pum#_options().highlight_selected,
-        \ prop_type, 0, g:pum#_namespace,
-        \ pum.cursor, 1, length)
+        \ prop_type, 0, pum.cursor, 1, length)
 endfunction
 
 function pum#popup#_redraw_horizontal_menu() abort
@@ -697,14 +694,14 @@ function pum#popup#_redraw_horizontal_menu() abort
     " Highlight the first item
     call s:highlight(
           \ options.highlight_selected,
-          \ 'pum_highlight_selected', 0, g:pum#_namespace,
+          \ 'pum_highlight_selected', 0,
           \ 1, 1, items[0]->get('abbr', items[0].word)->strwidth())
   endif
   if words->len() > 1
     call s:highlight(
           \ options.highlight_horizontal_separator,
-          \ 'pum_highlight_separator',
-          \ 0, g:pum#_namespace, 1, strwidth(words[0]) + 2, 1)
+          \ 'pum_highlight_separator', 0,
+          \ 1, strwidth(words[0]) + 2, 1)
   endif
 
   call pum#popup#_redraw()


### PR DESCRIPTION
## Problem

Highlights of `'hlsearch'` overrides `highlight_selected`.

Adjusting priority option of `matchaddpos()` does not resolve the issue because matches always override highlights of items, which uses textprop or extmark.

## Solusion

Replace `matchaddpos()` with other methods such as textprop or extmark.
