### PR TITLE
Fix highlight_scrollbar option handling. (neovim only)

### DIFF
--- a/autoload/pum/popup.vim
+++ b/autoload/pum/popup.vim
@@ -945,9 +945,6 @@ endfunction
 function s:set_window_options(id, options, highlight) abort
   let highlight = 'NormalFloat:' .. a:options['highlight_' .. a:highlight]
   let highlight ..= ',FloatBorder:FloatBorder,CursorLine:Visual'
-  if a:highlight ==# 'scrollbar'
-    let highlight ..= ',NormalFloat:None'
-  endif
   if &hlsearch
     " Disable 'hlsearch' highlight
     let highlight ..= ',Search:None,CurSearch:None'


### PR DESCRIPTION
Thank you for creating so many useful plugins.
I like that your plugins are highly adjustable.
I have fixed what seems to be a bug in this plugin, so could you please check it?

# Summary

Fixed the part where the highlight_scrollbar setting was overridden to NONE and disabled.

## Environment Information (Required!)

- pum.vim version(SHA1):8d3fd2b5de9166dea16a7cc1a0c1e23e40f63ae1

- OS:Ubuntu 22.04.2 LTS on Windows 10 x86_64

- neovim/Vim `:version` output:NVIM v0.10.0-dev-836+g6d93bdd45-Homebrew

## Provide a minimal init.vim/vimrc without plugin managers (Required!)

```vim
set rtp+=/path/to/pum.vim

function! g:Create_dummy_items(qty) abort
  let items = []
  for i in range(1, a:qty)
    call add(items, #{ word: 'test' .. i, kind: 'Test', menu: '[test]' })
  endfor
  return items
endfunction

highlight PmenuCustomSbar ctermfg=11
call pum#set_option(#{
      \   max_height: 20,
      \   highlight_scrollbar: 'PmenuCustomSbar',
      \   border: 'single',
      \   scrollbar_char: '┃',
      \ })

inoremap <C-n> <Cmd>call pum#map#insert_relative(+1)<CR>
inoremap <C-p> <Cmd>call pum#map#insert_relative(-1)<CR>
inoremap <C-Space> <Cmd>call pum#open(col('.'), g:Create_dummy_items(40))<CR>

```

## How to reproduce the problem from neovim/Vim startup (Required!)

1. Press `<C-Space>` in insert mode

## Screen shot (if possible)
- before  
  ![before](https://github.com/Shougo/pum.vim/assets/100141359/fdde8a2b-90ef-44e3-8738-362a26758c64)

- after  
  ![after](https://github.com/Shougo/pum.vim/assets/100141359/22ea501b-d478-4814-94b6-bf2a1dbb9853)
