### PR TITLE
fix: prevent unneeded ModeChanged fire at insert_line_complete

### DIFF
--- a/autoload/pum/map.vim
+++ b/autoload/pum/map.vim
@@ -449,7 +449,7 @@ function s:insert_line_complete(text) abort
   let s:save_completeopt = &completeopt
   let s:save_eventignore = &eventignore
   set completeopt=menu
-  set eventignore=CompleteDone
+  set eventignore=CompleteDone,ModeChanged
 
   call complete(pum#_get().startcol, [a:text])
 


### PR DESCRIPTION
# Problems summary
Unneeded `ModeChanged` fire at `complete()` call in `s:insert_line_complete()`
It breaks ddc.vim since https://github.com/Shougo/ddc.vim/commit/b6e598e63c47f9172ec4f64a21f9d81a32a186a8

## Expected
Suppress `ModeChanged`

## Environment Information (Required!)

- pum.vim version(SHA1): 19988d249e618808404c8d3fe70e7dcc9b51b784

- OS: Arch Linux

- neovim/Vim `:version` output: NVIM v0.10.0-dev-1301+g30d311ebc-dirty

## Provide a minimal init.vim/vimrc without plugin managers (Required!)

```vim
" Your minimal .vimrc
set runtimepath^=~/path/to/pum.vim/

function s:enter()
  call pum#open(1, [#{word: 'foo'}])
endfunction
autocmd ModeChanged *:i call s:enter()
autocmd ModeChanged * echom expand('<amatch>')

inoremap <C-n> <Cmd>call pum#map#insert_relative(1)<CR>
startinsert!
```

## How to reproduce the problem from neovim/Vim startup (Required!)

1. Press `<C-n>`
2. insert `foo` but pum re-opened

## Upload the log messages by `:redir` and `:message` (if errored)
 
`autocmd ModeChanged * echom expand('<amatch>')` result at while press `<C-n>`

```
i:ic
ic:i
i:ix
ix:i
```