### PR TITLE
fix: error of locked `s:pum_selected_id`

### DIFF
--- a/autoload/pum/popup.vim
+++ b/autoload/pum/popup.vim
@@ -1,5 +1,5 @@
 const s:pum_matched_id = 70
-const s:pum_selected_id = -1
+let s:pum_selected_id = -1
 
 const s:priority_highlight_item = 2
 const s:priority_highlight_column = 1


### PR DESCRIPTION
Since `s:pum_selected_id` was a constant value, it could not be reassigned in the process within `pum#popup#_redraw_selected()`, causing an error.
It was changed to const in commit 71ed0cb, so this PR changes it back to let.