### PR TITLE
feat: adjust preview height based on text wrapping

### DIFF
--- a/autoload/pum/popup.vim
+++ b/autoload/pum/popup.vim
@@ -929,8 +929,15 @@ function s:open_preview() abort
   if previewer->has_key('contents')
     let width = previewer.contents
           \ ->copy()->map({ _, val -> val->strwidth() })->max()
-    let height = previewer.contents->len()
     let width = [width, options.preview_width]->min()
+
+    " Calculate height with an algorithm derived from
+    " https://github.com/matsui54/denops-popup-preview.vim
+    " (MIT Licence; Copyright (c) 2021 Haruki Matsui)
+    let height = 0
+    for line in previewer.contents
+      let height += max([1, float2nr(ceil(strdisplaywidth(l:line) / str2float('' . width)))])
+    endfor
     let height = [height, options.preview_height]->min()
   else
     let width = options.preview_width


### PR DESCRIPTION
Currently, the height of the preview window can be too short if text wraps occur.
To solve the problem, I borrowed a piece of code from `matsui54/denops-popup-preview.vim`.

https://github.com/matsui54/denops-popup-preview.vim/blob/5a62ac76478791a86f17ac79f064ab302c41f5eb/autoload/vital/_popup_preview/VS/Vim/Window/FloatingWindow.vim?plain=1#L120-L123

## Before

![Screenshot_20240811_174748](https://github.com/user-attachments/assets/7e5af1e3-1c69-4f29-89bc-3438ab46f360)

## After

![Screenshot_20240811_174726](https://github.com/user-attachments/assets/b7c119d7-621b-4f5f-ab81-ebe52249a6db)

