### PR TITLE
Some 'border' options not working in Vim

### DIFF
--- a/autoload/pum/popup.vim
+++ b/autoload/pum/popup.vim
@@ -336,12 +336,19 @@ function pum#popup#_open(startcol, items, mode, insert) abort
           \ }
 
     if options.border->type() ==# v:t_string
-      if options.border ==# 'double'
-        let winopts.border = [2, 2, 2, 2]
-      elseif options.border !=# 'none'
+      if options.border !=# 'none'
         let winopts.border = [1, 1, 1, 1]
       endif
+
+      if &ambiwidth ==# 'single' && &encoding ==# 'utf-8'
+        if options.border ==# 'single'
+          let winopts.borderchars = ["─", "│", "─", "│", "┌", "┐", "┘", "└"]
+        elseif options.border ==# 'double'
+          let winopts.borderchars = ['═', '║', '═', '║', '╔', '╗', '╝', '╚']
+        endif
+      endif
     else
+      let winopts.border = [1, 1, 1, 1]
       let winopts.borderchars = options.border
     endif
 

--- a/doc/pum.txt
+++ b/doc/pum.txt
@@ -102,6 +102,9 @@ border
 		"shadow": neovim only.
 		array: Specifify the eight chars building up the border.
 
+		NOTE: If you use "single" or "double" in Vim,
+		'ambiwidth' must be "single" and 'encoding' must be "utf-8".
+
 		Default: "none"
 
                                                 *pum-option-commit_characters*


### PR DESCRIPTION
Currently, of the `border` options supported in Vim, only `double` works correctly.
The other options have the following problems:

- If `single` is set, a double line (Vim defaults) is displayed
- If array is set, no border is displayed

Both are caused by incorrect properties of the `popup_create` function.
The `border` property only recognizes 0 or non-zero values, so `borderchars` must be set to specify the border type.  Also, even if `borderchars` is set, if `border` is not set to a non-zero value, the border will not be displayed.

This pull request fixes the above problem.
However, if `&ambiwidth` is not `single` or `&encoding` is not `utf-8`, it will not render correctly, so Vim's default border display of ASCII characters will be used.

Please let me know if there is a problem with my implementation and I will correct it.
Thanks,